### PR TITLE
Updates for 2021 Graduates

### DIFF
--- a/events.html
+++ b/events.html
@@ -9,7 +9,7 @@
 
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0 maximum-scale=1" name="viewport"/>
-  
+
   <!-- FAVICONS -->
       <link href="Images/favicons/favicon.ico" rel="icon"/>
       <link href="Images/favicons/apple-touch-icon-180x180.png" rel="apple-touch-icon" sizes="180x180"/>
@@ -27,75 +27,75 @@
       <link href="Images/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72"/>
       <link href="Images/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114"/>
   <!-- END FAVICONS -->
-  
+
   <!-- SYSTEM-PAGE-TITLE and META-DATA-->
       <title>Darla Moore School of Business: </title>
-  
+
       <meta content="Tue, 17 Mar 2020 23:40:18 -0500" name="date"/>
   <!-- END SYSTEM-PAGE-TITLE and META-DATA-->
-  
+
   <!-- CSS LOADING -->
       <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,700,700italic,400italic|Roboto+Condensed:400,300" rel="stylesheet" type="text/css"/>
       <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
       <link href="Stylesheets/app_units.css" rel="stylesheet" type="text/css"/>
   <!-- END CSS LOADING -->
-  
-  
+
+
   <!-- "Must Have in the Header" Javascript -->
       <script src="https://cdn.jwplayer.com/libraries/QjJhlPkP.js" type="text/javascript"></script> <!-- JW PLAYER -->
       <script src="Scripts//modernizr.js" type="text/javascript"></script>
   <!-- END "Must Have in the Header" Javascript -->
   </head>
-  
+
   <body>
-  
-  
+
+
   <!--
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   All the content is wrapped in "off-canvas-wrap" and inner-wrap"
   the page content is in <section class="main-section">
   - this makes Phone Nav Possible
   *************************************************************** -->
-  
+
   <div class="off-canvas-wrap" data-offcanvas="">
     <div class="inner-wrap">
-  
-  
+
+
           <div id="sc-bar">
               <div class="row">
-  
+
           <!-- Phone "Tab" Bar Navigation-->
-  
+
               <nav class="tab-bar show-for-small-only"><!-- ADD BACK show-for-small to remove from desktop -->
                 <section class="right-small">
                   <a class="right-off-canvas-toggle menu-icon"><span></span></a>
                 </section>
-  
-  
+
+
                 <section class="left tab-bar-section">
           <a href="http://www.sc.edu/">
   <img alt="The University of South Carolina" class="sc" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
   <a href="https://sc.edu/study/colleges_schools/moore/index.php/">
   <img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
                 </section>
-  
+
               </nav>
-  
+
           <!--
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           NOTE: Phone navigation uses TAB BAR - Tablet and higher uses TOP BAR
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
-  
+
           <!--
           *******************************************************
           PHONE NAVIGATION - TAB BAR  (1 of 2 orange bars up top)
           ******************************************************* -->
-  
+
           <!-- Phone - off canvass navigation - the slide out navigation functionality -->
-  
+
               <aside class="right-off-canvas-menu">
                   <ul class="off-canvas-list">
-  
+
                   <!-- COLLEGE WIDE NAV - STATIC CONTENT -->
                     <li class="college closed">
                       <a class="off-canvas-submenu-call" href="#">
@@ -124,11 +124,11 @@
                       </ul>
                     </li>
                   <!-- END COLLEGE WIDE NAV - STATIC CONTENT -->
-  
+
                   <!-- UNIT NAV - DYNAMIC -->
-  
-  
-  
+
+
+
                         <!-- Unit Name and Dynamic Nav -->
                         <!-- SYSTEM-REGION NAV-SM-UNIT -->
                         <ul class="side-nav">
@@ -137,62 +137,62 @@
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                             <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                           </ul></li> 
+                           </ul></li>
                           <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                            <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                            <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                             <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                            </ul></li> 
+                            </ul></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                           <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                          </ul></li> 
+                          </ul></li>
                         <li class="open"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                         </ul>
-  
+
                         <!-- END SYSTEM-REGION NAV-SM-UNIT -->
-  
-  
-  
+
+
+
                   </ul> <!-- close ul class="off-canvas-list" -->
                   <!-- END UNIT NAV - DYNAMIC -->
-  
-  
+
+
                         <!-- Related Links -->
-  
-  
+
+
                         <!-- Office Contacts and Maps Pages -->
                         <!-- SYSTEM-REGION NAV-SM-OFFICE -->
                         <ul class="side-nav"><li><label>Office</label></li><li><a href="staff.php">Staff List</a></li>-->
                           <li><a href="contact-us.php">Contact Us</a></li></ul>
                         <!-- END SYSTEM-REGION NAV-SM-OFFICE -->
-  
-  
+
+
                         <!-- Address -->
                         <ul class="side-nav"><li><label>Address</label><span class="map-link"><a href="https://sc.edu/visit/map/?id=744#!m/223307" target="_blank"><i class="fa fa-map-marker">&#160;</i> Map</a></span></li><li class="phone-address"><h6>Department of Economics</h6><p>The University of South Carolina<br/>Darla Moore School of Business<br/>1014 Greene Street<br/>Columbia, South Carolina 29208<br/></p></li></ul>
-  
+
                         <!-- Unit Social Media Links -->
                         <ul class="side-nav"><li><label>Department of Economics Social Media</label></li><li class="unit-social"><a data-gtm-event="nav-unit-twitter" href="https://twitter.com/UofSC_Econ" title="twitter"><i class="fa fa-twitter-square fa-2x">&#160;</i><span class="hide">Twitter</span></a></li></ul>
               </aside>
-  
+
           <!--
           ***************************************
           END END END PHONE NAVIGATION - TAB BAR
           ***************************************
-  
+
           ***********************************************************************
           TABLET & DESKTOP ORANGE BAR LINKS - TOP BAR (2 of 2 orange bars up top)
           *********************************************************************** -->
-  
+
               <nav class="top-bar show-for-medium-up" data-topbar="" role="navigation">
                   <ul class="title-area">
                       <li class="name">
       <a href="https://sc.edu/study/colleges_schools/moore/index.php"><img alt="Darla Moore School of Business - The University of South Carolina" class="sc" src="Images/UofSC_Primary_Business_RGB_REV_G.png" width="200" height="40"/>
   </a>
-  
+
                       </li>
                       <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
                       <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a>
@@ -224,27 +224,27 @@
               *********************************************** -->
               </div> <!-- Close <div id="sc-bar"> -->
           </div> <!-- Close <div class="row"> -->
-  
+
           <section class="main-section">
-  
+
               <!--
               ***************************************************************
               UNIT Word Mark -  Accomodate SVG and GIF Fallback - Load Mechanism into Cascade CMS
               *************************************************************** -->
               <div id="identity-bar"><div class="row"><div class="row" id="logo_row">
-  
+
                         <!-- replaced by page-level template -->
   <!-- <div class="small-12 medium-8 columns"><a href="index.php"><img alt="The Economics Department" class="lockup" src="Images/logo-formal/departments/Economics.png"/></a></div> -->
-  
+
                         <!-- replaced by page-level template -->
-  
+
                         <!-- Unit Identity - "informal logo" -->
   <div class="hide-for-small medium-4 columns"></div>
-  
-  
-  
+
+
+
                    </div></div></div>
-  
+
               <div class="row content-secondary-page">
                   <!--
                   ***************************************
@@ -253,12 +253,12 @@
                   <div class="medium-9 medium-push-3 columns">
                       <div class="row" id="app">
                       <!-- Home Page Main Image -->
-  
+
                         <!-- SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                         <div class="medium-12 columns"><div class="slider-unit"><div class="slider-hp"><div><div class="slider-text-container left"><h2 class="text-out blue" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Explore Economics</a></h2><h3 class="text-out" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Our students are prepared for careers in finance, government, teaching, and more.</a></h3></div></div></div></div></div>
                         <!-- END SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                       <!-- END Home Page Main Image -->
-  
+
                       <!--
                       - - - - - - - - - -
                       - - - - - - - - - -
@@ -280,7 +280,7 @@
                       <!-- END SYSTEM-REGION HOMEPAGE-BODY = HOMEPAGE-NEWS ++ HOMEPAGE-EVENTS ++ HOMEPAGE-MAIN-CONTENT -->
 
 
-                
+
                     <!-- END Main Body Content -->
 
 
@@ -360,19 +360,19 @@
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                     <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                   </ul></li> 
+                   </ul></li>
                   <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                    <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                    <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                     <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                    </ul></li> 
+                    </ul></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                   <ul class='no-bullet'>
                   <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                   <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                  </ul></li> 
+                  </ul></li>
                 <li class="open"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                 </ul>
                 <!-- END SYSTEM-REGION NAV-MD-UP-UNIT -->

--- a/faculty.html
+++ b/faculty.html
@@ -9,7 +9,7 @@
 
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0 maximum-scale=1" name="viewport"/>
-  
+
   <!-- FAVICONS -->
       <link href="Images/favicons/favicon.ico" rel="icon"/>
       <link href="Images/favicons/apple-touch-icon-180x180.png" rel="apple-touch-icon" sizes="180x180"/>
@@ -27,75 +27,75 @@
       <link href="Images/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72"/>
       <link href="Images/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114"/>
   <!-- END FAVICONS -->
-  
+
   <!-- SYSTEM-PAGE-TITLE and META-DATA-->
       <title>Darla Moore School of Business: </title>
-  
+
       <meta content="Tue, 17 Mar 2020 23:40:18 -0500" name="date"/>
   <!-- END SYSTEM-PAGE-TITLE and META-DATA-->
-  
+
   <!-- CSS LOADING -->
       <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,700,700italic,400italic|Roboto+Condensed:400,300" rel="stylesheet" type="text/css"/>
       <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
       <link href="Stylesheets/app_units.css" rel="stylesheet" type="text/css"/>
   <!-- END CSS LOADING -->
-  
-  
+
+
   <!-- "Must Have in the Header" Javascript -->
       <script src="https://cdn.jwplayer.com/libraries/QjJhlPkP.js" type="text/javascript"></script> <!-- JW PLAYER -->
       <script src="Scripts//modernizr.js" type="text/javascript"></script>
   <!-- END "Must Have in the Header" Javascript -->
   </head>
-  
+
   <body>
-  
-  
+
+
   <!--
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   All the content is wrapped in "off-canvas-wrap" and inner-wrap"
   the page content is in <section class="main-section">
   - this makes Phone Nav Possible
   *************************************************************** -->
-  
+
   <div class="off-canvas-wrap" data-offcanvas="">
     <div class="inner-wrap">
-  
-  
+
+
           <div id="sc-bar">
               <div class="row">
-  
+
           <!-- Phone "Tab" Bar Navigation-->
-  
+
               <nav class="tab-bar show-for-small-only"><!-- ADD BACK show-for-small to remove from desktop -->
                 <section class="right-small">
                   <a class="right-off-canvas-toggle menu-icon"><span></span></a>
                 </section>
-  
-  
+
+
                 <section class="left tab-bar-section">
           <a href="http://www.sc.edu/">
   <img alt="The University of South Carolina" class="sc" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
   <a href="https://sc.edu/study/colleges_schools/moore/index.php/">
   <img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
                 </section>
-  
+
               </nav>
-  
+
           <!--
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           NOTE: Phone navigation uses TAB BAR - Tablet and higher uses TOP BAR
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
-  
+
           <!--
           *******************************************************
           PHONE NAVIGATION - TAB BAR  (1 of 2 orange bars up top)
           ******************************************************* -->
-  
+
           <!-- Phone - off canvass navigation - the slide out navigation functionality -->
-  
+
               <aside class="right-off-canvas-menu">
                   <ul class="off-canvas-list">
-  
+
                   <!-- COLLEGE WIDE NAV - STATIC CONTENT -->
                     <li class="college closed">
                       <a class="off-canvas-submenu-call" href="#">
@@ -124,11 +124,11 @@
                       </ul>
                     </li>
                   <!-- END COLLEGE WIDE NAV - STATIC CONTENT -->
-  
+
                   <!-- UNIT NAV - DYNAMIC -->
-  
-  
-  
+
+
+
                         <!-- Unit Name and Dynamic Nav -->
                         <!-- SYSTEM-REGION NAV-SM-UNIT -->
                         <ul class="side-nav">
@@ -137,64 +137,64 @@
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                             <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                           </ul></li> 
+                           </ul></li>
                           <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                            <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                            <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                             <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                            </ul></li> 
+                            </ul></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                           <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                          </ul></li> 
+                          </ul></li>
                         <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                         </ul>
-  
-  
-  
+
+
+
                         <!-- END SYSTEM-REGION NAV-SM-UNIT -->
-  
-  
-  
+
+
+
                   </ul> <!-- close ul class="off-canvas-list" -->
                   <!-- END UNIT NAV - DYNAMIC -->
-  
-  
+
+
                         <!-- Related Links -->
-  
-  
+
+
                         <!-- Office Contacts and Maps Pages -->
                         <!-- SYSTEM-REGION NAV-SM-OFFICE -->
                         <ul class="side-nav"><li><label>Office</label></li><li><a href="staff.php">Staff List</a></li>-->
                           <li><a href="contact-us.php">Contact Us</a></li></ul>
                         <!-- END SYSTEM-REGION NAV-SM-OFFICE -->
-  
-  
+
+
                         <!-- Address -->
                         <ul class="side-nav"><li><label>Address</label><span class="map-link"><a href="https://sc.edu/visit/map/?id=744#!m/223307" target="_blank"><i class="fa fa-map-marker">&#160;</i> Map</a></span></li><li class="phone-address"><h6>Department of Economics</h6><p>The University of South Carolina<br/>Darla Moore School of Business<br/>1014 Greene Street<br/>Columbia, South Carolina 29208<br/></p></li></ul>
-  
+
                         <!-- Unit Social Media Links -->
                         <ul class="side-nav"><li><label>Department of Economics Social Media</label></li><li class="unit-social"><a data-gtm-event="nav-unit-twitter" href="https://twitter.com/UofSC_Econ" title="twitter"><i class="fa fa-twitter-square fa-2x">&#160;</i><span class="hide">Twitter</span></a></li></ul>
               </aside>
-  
+
           <!--
           ***************************************
           END END END PHONE NAVIGATION - TAB BAR
           ***************************************
-  
+
           ***********************************************************************
           TABLET & DESKTOP ORANGE BAR LINKS - TOP BAR (2 of 2 orange bars up top)
           *********************************************************************** -->
-  
+
               <nav class="top-bar show-for-medium-up" data-topbar="" role="navigation">
                   <ul class="title-area">
                       <li class="name">
       <a href="https://sc.edu/study/colleges_schools/moore/index.php"><img alt="Darla Moore School of Business - The University of South Carolina" class="sc" src="Images/UofSC_Primary_Business_RGB_REV_G.png" width="200" height="40"/>
   </a>
-  
+
                       </li>
                       <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
                       <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a>
@@ -226,27 +226,27 @@
               *********************************************** -->
               </div> <!-- Close <div id="sc-bar"> -->
           </div> <!-- Close <div class="row"> -->
-  
+
           <section class="main-section">
-  
+
               <!--
               ***************************************************************
               UNIT Word Mark -  Accomodate SVG and GIF Fallback - Load Mechanism into Cascade CMS
               *************************************************************** -->
               <div id="identity-bar"><div class="row"><div class="row" id="logo_row">
-  
+
                         <!-- replaced by page-level template -->
   <!-- <div class="small-12 medium-8 columns"><a href="index.php"><img alt="The Economics Department" class="lockup" src="Images/logo-formal/departments/Economics.png"/></a></div> -->
-  
+
                         <!-- replaced by page-level template -->
-  
+
                         <!-- Unit Identity - "informal logo" -->
   <div class="hide-for-small medium-4 columns"></div>
-  
-  
-  
+
+
+
                    </div></div></div>
-  
+
               <div class="row content-secondary-page">
                   <!--
                   ***************************************
@@ -255,12 +255,12 @@
                   <div class="medium-9 medium-push-3 columns">
                       <div class="row" id="app">
                       <!-- Home Page Main Image -->
-  
+
                         <!-- SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                         <div class="medium-12 columns"><div class="slider-unit"><div class="slider-hp"><div><div class="slider-text-container left"><h2 class="text-out blue" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Explore Economics</a></h2><h3 class="text-out" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Our students are prepared for careers in finance, government, teaching, and more.</a></h3></div></div></div></div></div>
                         <!-- END SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                       <!-- END Home Page Main Image -->
-  
+
                       <!--
                       - - - - - - - - - -
                       - - - - - - - - - -
@@ -1042,7 +1042,7 @@
       <a href="CVs/woodworth_cv_april_2020.pdf">CV</a>, <a href="http://www.lwoodworth.com">Personal Website</a>
   </p>
   </div>
-</div> 
+</div>
 
 <br>
 
@@ -1080,7 +1080,7 @@
                       <!-- END SYSTEM-REGION HOMEPAGE-BODY = HOMEPAGE-NEWS ++ HOMEPAGE-EVENTS ++ HOMEPAGE-MAIN-CONTENT -->
 
 
-                
+
                     <!-- END Main Body Content -->
 
 
@@ -1160,19 +1160,19 @@
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                     <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                   </ul></li> 
+                   </ul></li>
                   <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                    <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                    <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                     <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                    </ul></li> 
+                    </ul></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                   <ul class='no-bullet'>
                   <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                   <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                  </ul></li> 
+                  </ul></li>
                 <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                 </ul>
                 <!-- END SYSTEM-REGION NAV-MD-UP-UNIT -->

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ the page content is in <section class="main-section">
         <a href="http://www.sc.edu/">
 <img alt="The University of South Carolina" class="sc" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
 <a href="https://sc.edu/study/colleges_schools/moore/index.php/">
-<img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>            
+<img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
 </section>
 
             </nav>
@@ -136,19 +136,19 @@ the page content is in <section class="main-section">
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                           <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                         </ul></li> 
+                         </ul></li>
                         <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                          <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                          <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                           <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                          </ul></li> 
+                          </ul></li>
                       <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                       <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                         <ul class='no-bullet'>
                         <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                         <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                        </ul></li> 
+                        </ul></li>
                       <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                       </ul>
 
@@ -378,7 +378,7 @@ the page content is in <section class="main-section">
                   <!-- SYSTEM-REGION HOMEPAGE-SHOUTOUT -->
                   <a href="https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/index.php/"><div class="small-12 panel-1"><h4>Master's in Economics</h4></div></a>
                   <a href="https://www.sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/index.php"><div class="small-12 panel-1"><h4>Ph.D. in Economics</h4></div></a>
-                  <a href="job_market_candidates.html"><div class="small-12 panel-2"><h4>Job Market Candidates</h4></div></a>
+                  <!-- <a href="job_market_candidates.html"><div class="small-12 panel-2"><h4>Job Market Candidates</h4></div></a> -->
                   <!-- END SYSTEM-REGION HOMEPAGE-SHOUTOUT -->
                 <!-- END Shout Out links -->
 
@@ -413,19 +413,19 @@ the page content is in <section class="main-section">
                       <ul class='no-bullet'>
                       <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                       <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                     </ul></li> 
+                     </ul></li>
                     <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                       <ul class='no-bullet'>
                       <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                      <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                      <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                       <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                      </ul></li> 
+                      </ul></li>
                   <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                   <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                     <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                    </ul></li> 
+                    </ul></li>
                   <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                   </ul>
                   <!-- END SYSTEM-REGION NAV-MD-UP-UNIT -->

--- a/phd_students.html
+++ b/phd_students.html
@@ -144,7 +144,7 @@ the page content is in <section class="main-section">
                           <li class="open"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                            <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                            <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                             <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
                             </ul></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
@@ -389,7 +389,7 @@ the page content is in <section class="main-section">
                     <li class="open"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                       <ul class='no-bullet'>
                       <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                      <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                      <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                       <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
                       </ul></li>
                   <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>

--- a/phd_students.html
+++ b/phd_students.html
@@ -62,43 +62,43 @@ the page content is in <section class="main-section">
 
 <div class="off-canvas-wrap" data-offcanvas="">
     <div class="inner-wrap">
-  
-  
+
+
           <div id="sc-bar">
               <div class="row">
-  
+
           <!-- Phone "Tab" Bar Navigation-->
-  
+
               <nav class="tab-bar show-for-small-only"><!-- ADD BACK show-for-small to remove from desktop -->
                 <section class="right-small">
                   <a class="right-off-canvas-toggle menu-icon"><span></span></a>
                 </section>
-  
-  
+
+
                 <section class="left tab-bar-section">
           <a href="http://www.sc.edu/">
   <img alt="The University of South Carolina" class="sc" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
   <a href="https://sc.edu/study/colleges_schools/moore/index.php/">
   <img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
                 </section>
-  
+
               </nav>
-  
+
           <!--
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           NOTE: Phone navigation uses TAB BAR - Tablet and higher uses TOP BAR
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
-  
+
           <!--
           *******************************************************
           PHONE NAVIGATION - TAB BAR  (1 of 2 orange bars up top)
           ******************************************************* -->
-  
+
           <!-- Phone - off canvass navigation - the slide out navigation functionality -->
-  
+
               <aside class="right-off-canvas-menu">
                   <ul class="off-canvas-list">
-  
+
                   <!-- COLLEGE WIDE NAV - STATIC CONTENT -->
                     <li class="college closed">
                       <a class="off-canvas-submenu-call" href="#">
@@ -127,11 +127,11 @@ the page content is in <section class="main-section">
                       </ul>
                     </li>
                   <!-- END COLLEGE WIDE NAV - STATIC CONTENT -->
-  
+
                   <!-- UNIT NAV - DYNAMIC -->
-  
-  
-  
+
+
+
                         <!-- Unit Name and Dynamic Nav -->
                         <!-- SYSTEM-REGION NAV-SM-UNIT -->
                         <ul class="side-nav">
@@ -140,65 +140,65 @@ the page content is in <section class="main-section">
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                             <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                           </ul></li> 
+                           </ul></li>
                           <li class="open"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
                             <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
                             <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                            </ul></li> 
+                            </ul></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                           <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                          </ul></li> 
+                          </ul></li>
                         <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                         </ul>
-  
-  
-  
-  
+
+
+
+
                         <!-- END SYSTEM-REGION NAV-SM-UNIT -->
-  
-  
-  
+
+
+
                   </ul> <!-- close ul class="off-canvas-list" -->
                   <!-- END UNIT NAV - DYNAMIC -->
-  
-  
+
+
                         <!-- Related Links -->
-  
-  
+
+
                         <!-- Office Contacts and Maps Pages -->
                         <!-- SYSTEM-REGION NAV-SM-OFFICE -->
                         <ul class="side-nav"><li><label>Office</label></li><li><a href="staff.php">Staff List</a></li>-->
                           <li><a href="contact-us.php">Contact Us</a></li></ul>
                         <!-- END SYSTEM-REGION NAV-SM-OFFICE -->
-  
-  
+
+
                         <!-- Address -->
                         <ul class="side-nav"><li><label>Address</label><span class="map-link"><a href="https://sc.edu/visit/map/?id=744#!m/223307" target="_blank"><i class="fa fa-map-marker">&#160;</i> Map</a></span></li><li class="phone-address"><h6>Department of Economics</h6><p>The University of South Carolina<br/>Darla Moore School of Business<br/>1014 Greene Street<br/>Columbia, South Carolina 29208<br/></p></li></ul>
-  
+
                         <!-- Unit Social Media Links -->
                         <ul class="side-nav"><li><label>Department of Economics Social Media</label></li><li class="unit-social"><a data-gtm-event="nav-unit-twitter" href="https://twitter.com/UofSC_Econ" title="twitter"><i class="fa fa-twitter-square fa-2x">&#160;</i><span class="hide">Twitter</span></a></li></ul>
               </aside>
-  
+
           <!--
           ***************************************
           END END END PHONE NAVIGATION - TAB BAR
           ***************************************
-  
+
           ***********************************************************************
           TABLET & DESKTOP ORANGE BAR LINKS - TOP BAR (2 of 2 orange bars up top)
           *********************************************************************** -->
-  
+
               <nav class="top-bar show-for-medium-up" data-topbar="" role="navigation">
                   <ul class="title-area">
                       <li class="name">
       <a href="https://sc.edu/study/colleges_schools/moore/index.php"><img alt="Darla Moore School of Business - The University of South Carolina" class="sc" src="Images/UofSC_Primary_Business_RGB_REV_G.png" width="200" height="40"/>
   </a>
-  
+
                       </li>
                       <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
                       <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a>
@@ -230,27 +230,27 @@ the page content is in <section class="main-section">
               *********************************************** -->
               </div> <!-- Close <div id="sc-bar"> -->
           </div> <!-- Close <div class="row"> -->
-  
+
           <section class="main-section">
-  
+
               <!--
               ***************************************************************
               UNIT Word Mark -  Accomodate SVG and GIF Fallback - Load Mechanism into Cascade CMS
               *************************************************************** -->
               <div id="identity-bar"><div class="row"><div class="row" id="logo_row">
-  
+
                         <!-- replaced by page-level template -->
   <!-- <div class="small-12 medium-8 columns"><a href="index.php"><img alt="The Economics Department" class="lockup" src="Images/logo-formal/departments/Economics.png"/></a></div> -->
-  
+
                         <!-- replaced by page-level template -->
-  
+
                         <!-- Unit Identity - "informal logo" -->
   <div class="hide-for-small medium-4 columns"></div>
-  
-  
-  
+
+
+
                    </div></div></div>
-  
+
               <div class="row content-secondary-page">
 
                 <!--
@@ -290,19 +290,15 @@ the page content is in <section class="main-section">
   <br>
 <p><strong>Haimiti Aerfate</strong><br/> <br>  </p>
 <p><strong>Saharnaz Babaei Balderlou</strong><br/> Research Interests: International Economics, Financial Economics, Globalization <br>  </p>
-<p><strong>Eren Bilen</strong><br/> Research Interests: Applied Microeconomics, Tournaments, Health Economics <br> <a href="https://erenbilen.weebly.com" rel="noopener" target="_blank">Personal website</a> </p>
 <p><strong>Justin Coker</strong><br/> Research Interests: Labor and Education Economics; Applied Microeconomics; Game Theory <br> </p>
 <p><strong>Mahyar Ebrahimitorki</strong><br/> <br>  </p>
-<p><strong>Matthew Harvey</strong><br/> Research Interests: Institutions, Crime, Economic History <br>  <a href="https://mharvey2015.wixsite.com/matttheeconguy">Personal Website</a></p>
 <p><strong>Diana Idiaghe</strong><br/> <br>  </p>
 <p><strong>Mohammad Jakaria</strong><br/> <br>  </p>
 <p><strong>Iddrisu Kambala Mohammed </strong><br/>  <br>  </p>
 <p><strong>Angela Shoulders</strong><br/>  <br>  </p>
 <p><strong>Kaleigh Strohl</strong><br/>  <a href="https://kstrohl214.wixsite.com/kaleighstrohl" rel="noopener" target="_blank">Personal website</a> </p>
 <p><strong>Jonathan Tregde</strong><br/> Research Interests: Macroeconomics, Monetary Economics, Monetary policy <br> </p>
-<p><strong>Alexandra Troidl</strong><br/> Research Interests: Regional/Urban Economics, Economic Development and Growth, International Economics <br> <a href="https://alexandradinu10.wixsite.com/website">Personal Website</a> </p>
 <p><strong>Foteini Tzachrista</strong><br/> Research Interests: Behavioral Economics, Neuroeconomics, Quantitative Research <br>  </p>
-<p><strong>Zehra Valencia Lopez</strong><br/> Research Interests: Behavioral Economics, Health Economics, Applied Microeconomics <br> <a href="https://sites.google.com/prod/view/zehravalencia/home" rel="noopener" target="_blank">Personal website</a> </p>
 
 
 <div class="figure half left"></div></div></div>
@@ -354,7 +350,7 @@ the page content is in <section class="main-section">
 
                 <!-- Shout Out links -->
                   <!-- SYSTEM-REGION HOMEPAGE-SHOUTOUT -->
-                  
+
                   <!-- END SYSTEM-REGION HOMEPAGE-SHOUTOUT -->
                 <!-- END Shout Out links -->
 
@@ -389,19 +385,19 @@ the page content is in <section class="main-section">
                       <ul class='no-bullet'>
                       <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                       <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                     </ul></li> 
+                     </ul></li>
                     <li class="open"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                       <ul class='no-bullet'>
                       <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
                       <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
                       <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                      </ul></li> 
+                      </ul></li>
                   <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                   <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                     <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                    </ul></li> 
+                    </ul></li>
                   <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                   </ul>
                   <!-- END SYSTEM-REGION NAV-MD-UP-UNIT -->

--- a/research.html
+++ b/research.html
@@ -9,7 +9,7 @@
 
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0 maximum-scale=1" name="viewport"/>
-  
+
   <!-- FAVICONS -->
       <link href="Images/favicons/favicon.ico" rel="icon"/>
       <link href="Images/favicons/apple-touch-icon-180x180.png" rel="apple-touch-icon" sizes="180x180"/>
@@ -27,75 +27,75 @@
       <link href="Images/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72"/>
       <link href="Images/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114"/>
   <!-- END FAVICONS -->
-  
+
   <!-- SYSTEM-PAGE-TITLE and META-DATA-->
       <title>Darla Moore School of Business: </title>
-  
+
       <meta content="Tue, 17 Mar 2020 23:40:18 -0500" name="date"/>
   <!-- END SYSTEM-PAGE-TITLE and META-DATA-->
-  
+
   <!-- CSS LOADING -->
       <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,700,700italic,400italic|Roboto+Condensed:400,300" rel="stylesheet" type="text/css"/>
       <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
       <link href="Stylesheets/app_units.css" rel="stylesheet" type="text/css"/>
   <!-- END CSS LOADING -->
-  
-  
+
+
   <!-- "Must Have in the Header" Javascript -->
       <script src="https://cdn.jwplayer.com/libraries/QjJhlPkP.js" type="text/javascript"></script> <!-- JW PLAYER -->
       <script src="Scripts//modernizr.js" type="text/javascript"></script>
   <!-- END "Must Have in the Header" Javascript -->
   </head>
-  
+
   <body>
-  
-  
+
+
   <!--
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   All the content is wrapped in "off-canvas-wrap" and inner-wrap"
   the page content is in <section class="main-section">
   - this makes Phone Nav Possible
   *************************************************************** -->
-  
+
   <div class="off-canvas-wrap" data-offcanvas="">
     <div class="inner-wrap">
-  
-  
+
+
           <div id="sc-bar">
               <div class="row">
-  
+
           <!-- Phone "Tab" Bar Navigation-->
-  
+
               <nav class="tab-bar show-for-small-only"><!-- ADD BACK show-for-small to remove from desktop -->
                 <section class="right-small">
                   <a class="right-off-canvas-toggle menu-icon"><span></span></a>
                 </section>
-  
-  
+
+
                 <section class="left tab-bar-section">
           <a href="http://www.sc.edu/">
   <img alt="The University of South Carolina" class="sc" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
   <a href="https://sc.edu/study/colleges_schools/moore/index.php/">
   <img alt="Darla Moore School of Business - The University of South Carolina" class="cla" onerror="this.onerror=null;this.src='Images/UofSC_Primary_RGB_REV_G.png'" src="Images/UofSC_Primary_RGB_REV_G.png"/></a>
                 </section>
-  
+
               </nav>
-  
+
           <!--
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           NOTE: Phone navigation uses TAB BAR - Tablet and higher uses TOP BAR
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
-  
+
           <!--
           *******************************************************
           PHONE NAVIGATION - TAB BAR  (1 of 2 orange bars up top)
           ******************************************************* -->
-  
+
           <!-- Phone - off canvass navigation - the slide out navigation functionality -->
-  
+
               <aside class="right-off-canvas-menu">
                   <ul class="off-canvas-list">
-  
+
                   <!-- COLLEGE WIDE NAV - STATIC CONTENT -->
                     <li class="college closed">
                       <a class="off-canvas-submenu-call" href="#">
@@ -124,11 +124,11 @@
                       </ul>
                     </li>
                   <!-- END COLLEGE WIDE NAV - STATIC CONTENT -->
-  
+
                   <!-- UNIT NAV - DYNAMIC -->
-  
-  
-  
+
+
+
                         <!-- Unit Name and Dynamic Nav -->
                         <!-- SYSTEM-REGION NAV-SM-UNIT -->
                         <ul class="side-nav">
@@ -137,64 +137,64 @@
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                             <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                           </ul></li> 
+                           </ul></li>
                           <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                             <ul class='no-bullet'>
                             <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                            <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                            <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                             <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                            </ul></li> 
+                            </ul></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                         <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                           <ul class='no-bullet'>
                           <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                           <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                          </ul></li> 
+                          </ul></li>
                         <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                         </ul>
-  
-  
-  
+
+
+
                         <!-- END SYSTEM-REGION NAV-SM-UNIT -->
-  
-  
-  
+
+
+
                   </ul> <!-- close ul class="off-canvas-list" -->
                   <!-- END UNIT NAV - DYNAMIC -->
-  
-  
+
+
                         <!-- Related Links -->
-  
-  
+
+
                         <!-- Office Contacts and Maps Pages -->
                         <!-- SYSTEM-REGION NAV-SM-OFFICE -->
                         <ul class="side-nav"><li><label>Office</label></li><li><a href="staff.php">Staff List</a></li>-->
                           <li><a href="contact-us.php">Contact Us</a></li></ul>
                         <!-- END SYSTEM-REGION NAV-SM-OFFICE -->
-  
-  
+
+
                         <!-- Address -->
                         <ul class="side-nav"><li><label>Address</label><span class="map-link"><a href="https://sc.edu/visit/map/?id=744#!m/223307" target="_blank"><i class="fa fa-map-marker">&#160;</i> Map</a></span></li><li class="phone-address"><h6>Department of Economics</h6><p>The University of South Carolina<br/>Darla Moore School of Business<br/>1014 Greene Street<br/>Columbia, South Carolina 29208<br/></p></li></ul>
-  
+
                         <!-- Unit Social Media Links -->
                         <ul class="side-nav"><li><label>Department of Economics Social Media</label></li><li class="unit-social"><a data-gtm-event="nav-unit-twitter" href="https://twitter.com/UofSC_Econ" title="twitter"><i class="fa fa-twitter-square fa-2x">&#160;</i><span class="hide">Twitter</span></a></li></ul>
               </aside>
-  
+
           <!--
           ***************************************
           END END END PHONE NAVIGATION - TAB BAR
           ***************************************
-  
+
           ***********************************************************************
           TABLET & DESKTOP ORANGE BAR LINKS - TOP BAR (2 of 2 orange bars up top)
           *********************************************************************** -->
-  
+
               <nav class="top-bar show-for-medium-up" data-topbar="" role="navigation">
                   <ul class="title-area">
                       <li class="name">
       <a href="https://sc.edu/study/colleges_schools/moore/index.php"><img alt="Darla Moore School of Business - The University of South Carolina" class="sc" src="Images/UofSC_Primary_Business_RGB_REV_G.png" width="200" height="40"/>
   </a>
-  
+
                       </li>
                       <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
                       <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a>
@@ -226,27 +226,27 @@
               *********************************************** -->
               </div> <!-- Close <div id="sc-bar"> -->
           </div> <!-- Close <div class="row"> -->
-  
+
           <section class="main-section">
-  
+
               <!--
               ***************************************************************
               UNIT Word Mark -  Accomodate SVG and GIF Fallback - Load Mechanism into Cascade CMS
               *************************************************************** -->
               <div id="identity-bar"><div class="row"><div class="row" id="logo_row">
-  
+
                         <!-- replaced by page-level template -->
   <!-- <div class="small-12 medium-8 columns"><a href="index.php"><img alt="The Economics Department" class="lockup" src="Images/logo-formal/departments/Economics.png"/></a></div> -->
-  
+
                         <!-- replaced by page-level template -->
-  
+
                         <!-- Unit Identity - "informal logo" -->
   <div class="hide-for-small medium-4 columns"></div>
-  
-  
-  
+
+
+
                    </div></div></div>
-  
+
               <div class="row content-secondary-page">
                   <!--
                   ***************************************
@@ -255,12 +255,12 @@
                   <div class="medium-9 medium-push-3 columns">
                       <div class="row" id="app">
                       <!-- Home Page Main Image -->
-  
+
                         <!-- SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                         <div class="medium-12 columns"><div class="slider-unit"><div class="slider-hp"><div><div class="slider-text-container left"><h2 class="text-out blue" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Explore Economics</a></h2><h3 class="text-out" id="text-animate-0"><a href="https://sc.edu/study/colleges_schools/moore/economics/undergraduate/prospective/Admission%20and%20Declaring%20the%20Major.php">Our students are prepared for careers in finance, government, teaching, and more.</a></h3></div></div></div></div></div>
                         <!-- END SYSTEM-REGION HOMEPAGE-MAIN-IMAGE -->
                       <!-- END Home Page Main Image -->
-  
+
                       <!--
                       - - - - - - - - - -
                       - - - - - - - - - -
@@ -273,977 +273,977 @@
   <br>
 
   <h3>Forthcoming</h3>
-                              
+
   <ul>
-     
+
      <li><strong>Addison, John, Ozturk, Orgul D., </strong>and Chen, Liwen. "Occupational Skill Mismatch: Differences by Gender and Cohort."
         <em>Labor Relations Review, </em>forthcoming.<strong>&nbsp;</strong></li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> “Bias in Small-Sample Inference with Count-Data Models.” <em>The American Statistician</em>, forthcoming.
      </li>
-     
+
      <li>Boosey, L., <strong>Brookins, P.,</strong> Ryvkin, D. “Information disclosure in contests with endogenous entry: An experiment.”
         <em>Management Science,</em> forthcoming.
      </li>
-     
+
      <li>Benzell, Seth, Berkovich, Efraim, Carroll, Robert, Cuevas,Guillermo, <strong>DeBacker, Jason</strong>, Diamond, John, Evans, Richard W., Gokhale, Jagadeesh, Kotlikoff, Laurence, Mackie,
         James, Moore, Nelson, Jaeger, Pecoraro, Rachel,&nbsp; Phillips, Kerk, Pizzola, Brandon,
         Ye, Victor and Zodrow, George. “Macroeconomic Effects of Reducing OASI to Payable
         Benefits: A Comparison of Seven Overlapping Generations Models.” <em>National Tax Journal,</em> forthcoming.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong>, Heim, Bradley, Ramnath, Shanthi and Ross, Justin. “The Impact of State Taxes on
         Small Businesses: Evidence from the 2012 Kansas Income Tax Reform.” <em>Journal of Public Economics,</em> forthcoming.
      </li>
-     
+
      <li><span>Deb, K., <strong>Hauk, W.R.</strong> The Impact of Chinese Imports on Indian Wage Inequality. Forthcoming in Indian Journal
            of Labour Economics (2020).</span></li>
-     
+
      <li><strong>Jensen, Christian.</strong> “Discretion Rather than Rules? Outdated Optimal Commitment Plans versus Discretionary
         Policymaking,” <em>The B.E. Journal of Macroeconomics, </em>forthcoming.
      </li>
-     
+
      <li>Sharma,Luv, Queenan, Carrie, and <strong>Orgul D. Ozturk.</strong> “The Impact of Information Technology and Communication on Medical Malpractice Lawsuits.”
         <em>Production and Operations </em><em>Management,</em> forthcoming.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L., and Zhan, Crystal. </strong>“The Impact of Natural Disasters on US Home Ownership.” <em>Journal of the Association of Environmental and Resource Economists</em>, forthcoming.<strong>&nbsp;</strong></li>
-     
+
      <li><strong>Woodworth, Lindsey</strong>, and Holmes, James. F. “Just a Minute: The Effect of Emergency Department Wait Time
         on the Cost of Care.” <em>Economic Inquiry</em>, forthcoming.&nbsp;
      </li>
-     
+
      <li>Melnikow, Joy, Evans, Ethan, Xing, Guibo, Durbin, Shauna, Ritley, Dominique, Daniels,
         Brock, and <strong>Woodworth, Lindsey</strong>. “Primary Care Access to New Patient Appointments for California Medicaid Enrollees:
         A Simulated Patient (Secret Shopper) Study.” <em>Annals of Family Medicine</em>, forthcoming.
      </li>
-     
+
   </ul>
-  
+
   <h3>2019 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Grunau, Philipp, and Teixeira, Paulino. “Worker Representation and
         Temporary Employment in Germany: The Deployment and Extent of Fixed-Term Contracts
         and Temporary Agency Work." <em>Journal of Participation and Employee Ownership,</em> Vol. 2, Issue 1, 24-46.&nbsp;
      </li>
-     
+
      <li><strong>Addison, John,</strong> and Teixeira, Paulino. "Strikes, Employee Workplace Representation, Unionism, and
         Industrial Relations Quality in European Establishments." <em>Journal of Economic Behavior and Organization</em>, Vol. 159, 109-133 (with Paulino Teixeira).&nbsp;
      </li>
-     
+
      <li><strong>Addison, John,</strong> and Teixeira, Paulino. "Workplace Employee Representation and Industrial Relations
         Performance: Cross-Country Evidence from the 2013 European Company Survey."&nbsp; <em>Jahrbücher für Nationalökonomie und Statistik/Journal of Economics and Statistics</em>, Vol. 239, No. 1, 111-154.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher</strong> and Eun Son Lim. “Free Trade Agreements and Market Integration: Evidence from South
         Korea.” <em>Journal of International Money and Finance</em>. 90:241-56.&nbsp;
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher and John McDermott.</strong> “Debt and Depression.” <em>Contemporary Economic Policy.</em> 37(4):714-30.
      </li>
-     
+
      <li>Boosey, L., <strong>Brookins, P.,</strong> Ryvkin, D. “Contests between groups of unknown size.” <em>Games and Economic Behavior</em>, 113: 756-769.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong>, Evans, Richard and Phillips, Kerk L.&nbsp; “Integrating Microsimulation Models of Tax
         Policy into a DGE Macroeconomic Model.” <em>Public Finance Review</em>, 47(2): 207-275.
      </li>
-     
+
      <li><strong>Gordanier, John, Hauk, William,</strong> and Sankaran, Chandini. “The Effects of Early Student Intervention on Economics Grades<em>.”&nbsp; Economics of Education Review,</em> 72(1):23-29.
      </li>
-     
+
      <li>Chen, Liwen, <strong>Gordanier, John and Ozturk, Orgul D.</strong>“Task Followers and Labor Market Outcomes” <em>Journal of Labor Research,</em> V 40, I 2, 181–201.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.,</strong> DeShazo, J.R., and Carson, Richard T. “Demand for Green Refueling Infrastructure<em>.” Environmental and Resource Economics,</em> 74: 131-157.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.,</strong> and Sankaran, Chandini. “Averting Behavior among Singaporeans during Indonesian Forest
         Fires.” <em>Environmental and Resource Economics,</em> 74:159-180.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.</strong> and Dua, Rubal. “Assessing the Effectiveness of California's "Replace your Ride.”
         <em>Energy Policy</em>, 132: 318-323.
      </li>
-     
+
      <li>Duerr, Isaac, Knight, Thomas, and <strong>Woodworth, Lindsey</strong>. “Evidence on the Effect of Political Platform Transparency on Partisan Voting.”&nbsp;<em>Eastern Economic Journal</em>,&nbsp;<em>45</em>(3), 331-349.
      </li>
-     
+
   </ul>
-  
+
   <h3>2018 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John,</strong> Guimarães, Paulo, Portugal, Pedro, and Torres, Sónia. "The Sources of Wage Variation
         and the Direction of Assortative Matching: A Three-Way High Dimensional Fixed-Effects
         Regression Model." <em>Labour</em> <em>Economics</em>, Vol. 54, 47-60.
      </li>
-     
+
      <li><strong>Addison, John, Ozturk, Orgul,</strong> and Wang, Si. "The Occupational Feminization of Wages." <em>Industrial and Labor Relations Review</em>, Vol. 71, No. 1, 208-241.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher, John McDermott</strong>, and Warren E. Weber. “Time Aggregation and the Relationship between Inflation and
         Money Growth.” <em>Journal of Money, Credit, and Banking.</em> 50:351-75.
      </li>
-     
+
      <li><strong>Brookins, P.,</strong> Lightle, J., Ryvkin, D. “Sorting and communication in weak-link group contests.”
         <em>Journal of Economic Behavior and Organization,</em> 152: 64-80.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong>, Goodman, Lucas, Heim, Bradley, Ramnath, Shanthi, and Ross, Justin.&nbsp; “Pass-through
         Entity Responses to Preferential Tax Rates: Evidence on Economic Activity and Owner
         Compensation in Kansas.” <em>National Tax Journal</em>, 71(4): 687-706.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong>, Heim, Bradley, Tran, Anh, and Yuskavage, Alex.&nbsp; “The Effects of IRS Audits on EITC
         Participants.” <em>National Tax Journal,</em> 71(3): 451-484.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong>, Heim, Bradley, Tran, Anh, and Yuskavage, Alex.&nbsp; “Once Bitten, Twice Shy? The Impact
         of IRS Audits on Filer Behavior.” <em>Journal of Law and Economics</em>, 61(1): 1-35.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong> and Kasher, Roy.&nbsp; “Effective Tax Rates on Business Investment Under the Tax Cuts
         and Jobs Act.” <em>AEI Economic Perspectives</em>, 22: 1-7.
      </li>
-     
+
      <li>Cotti, Chad, <strong>Gordanier, John</strong> and <strong>Ozturk, Orgul D.</strong> “When does it Count? The Timing of Food Stamp Receipt and Educational Performance
         in Mathematics.” <em>Economics of Education Review,</em> Volume 66,&nbsp; 40-50.
      </li>
-     
+
      <li>Cotti, Chad, <strong>Gordanier, John</strong> and <strong>Ozturk, Orgul D.</strong> “Class Meeting Frequency, Start Times, and Academic Performance” Economics of Education
         Review, Volume 62, 12-15.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> “An Endogenously Derived AK-Model of Economic Growth,” <em>Macroeconomic Dynamics,</em> 22: 2182-2200.
      </li>
-     
+
      <li>De Roos, Nicholas, <strong>Matros, Alexander, </strong>Smirnove, Vladimir and Wait, Andrew. “Shipwrecks and treasure hunters.” <em>Journal of Economic Dynamics and Control,</em> 90: 259-283.
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> “Lloyd Shapley and Chess with Imperfect Information.” <em>Games and Economic Behavior,</em> 108: 600-613.
      </li>
-     
+
      <li><strong>Ozturk, Orgul D.</strong>, McDermott, Suzanne, Turk, Margaret, and Xu, Xinling.“Physical Activity and Disability:
         An Analysis on How Activity Might Lower Medical Expenditures.” <em>Journal of Physical Activity and Health,</em> Aug 1;15(8), 564-571.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.</strong> and Dua, Rubal. “Gasoline Savings from Clean Vehicle Adoption.” <em>Energy Policy,</em> 120: 418-424.
      </li>
-     
+
      <li><strong>Zhan, Crystal.</strong> “School Choice Programs and Location Choices of Private Schools.” <em>Economic Inquiry,</em> 56(3), 1622-1645.&nbsp;
      </li>
-     
+
   </ul>
-  
+
   <h3>2017 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Evers, Katalin, and Teixeira, Paulino. "Contract Innovation in Germany:
         An Economic Evaluation of Pacts for Employment and Competitiveness." <em>British Journal of Industrial Relations,</em> Vol. 55, No. 3, 500-526.&nbsp;
      </li>
-     
+
      <li><strong>Addison, John,</strong> Portugal, Pedro, and Vilares, Hugo. "Unions and Collective Bargaining in the Wake
         of the Great Recession: Evidence from Portugal<em>." British Journal of Industrial Relations,</em> Vol. 55, No. 3, 551-576.
      </li>
-     
+
      <li><strong>Addison, John.</strong> "The Effects of Minimum Wages on Employment: The Legacy of Myth and&nbsp;Measurement,"
         <em>Industrial and Labor Relations Review</em>, Vol. 70, No. 3, 814-818. &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
         &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;
      </li>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Pahnke, André, and Teixeira, Paulino. "Demise of a Model? The State
         of Collective Bargaining and Worker Representation in Germany," <em>Economic and Industrial Democracy,</em> Vol. 38, No. 2, 193-234.
      </li>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Evers, Katalin, and Teixeira, Paulino. "Collective Bargaining and
         Innovation in Germany: A Case of Cooperative Industrial Relations?" <em>Industrial Relations,</em> Vol. 56, No. 1, 73-121.
      </li>
-     
+
      <li>Boosey, L., <strong>Brookins, P.,</strong> Ryvkin, D. “Contests with group size uncertainty: Experimental evidence.” <em>Games and Economic Behavior,</em> 105: 212-229.
      </li>
-     
+
      <li><strong>DeBacker, Jason</strong> and Routon, Wes. “Expectations, Education, and Opportunity.” <em>Journal of Economic Psychology,</em> 59: 29-44.
      </li>
-     
+
      <li>Castellari, Elena, Cotti, Chad, <strong>Gordanier, John</strong>, and <strong>Ozturk, Orgul D.</strong> “ Does the Timing of Food Stamp Distribution Matter? A Panel-Data Analysis of Monthly
         Purchasing Patterns of US Households.” <em>Health Economics</em>, Volume 26, Issue 11, 1380–1393.&nbsp;
      </li>
-     
+
      <li>Deb, Kaveri and <strong>Hauk, William.</strong> “RCA Indices, Multinational Production and the Ricardian Trade Model.” <em>International Economics and Economic Policy,</em> 14(1):1-25.
      </li>
-     
+
      <li><strong>Hauk, William. </strong>“Endogeneity Bias and Growth Regressions.” <em>Journal of Macroeconomics</em>, 51(1):143-161.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> “Aggregate Evidence of Price Rigidities and the Inflation-Output Trade-Off: A Factor
         Analysis of Factor Shares,” <em>Annals of Economics and Finance</em>, 18: 227-252.
      </li>
-     
+
      <li>Duffy, John and <strong>Matros, Alexander.</strong> “Stochastic Asymmetric Blotto Games: An Experimental Study.” <em>Journal of Economic Behavior &amp; Organization,</em> 139: 88-105.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.</strong> and DeShazo, J.R. “How Does the Presence of HOV Lanes Affect Plug-in Electric Vehicle
         Adoption in California? A Generalized Propensity Score Approach.” <em>Journal of Environmental Economics and Management,</em> 85: 146-170.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.,</strong> and Sankaran, Chandini. “The Impact of Indonesian Forest Fires on Singaporean Pollution
         and Health.” <em>American Economic Review: Papers and Proceedings,</em> 107(5).
      </li>
-     
+
      <li>DeShazo, J.R., <strong>Sheldon, Tamara L.,</strong> and Carson, Richard T. “Designing Policy Incentives for Cleaner Technologies: Lessons
         from California’s Plug-in Electric Vehicle Rebate Program.” <em>Journal of Environmental Economics and Management,</em> 84: 18-43.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.,</strong> DeShazo, J.R., and Carson, Richard T. “Demand for Battery-electric and Plug-in Hybrid
         Vehicles: Policy Lessons for an Emerging Market.” <em>Economic Inquiry,</em> 55(2): 695-713.
      </li>
-     
+
      <li><strong>Sheldon, Tamara L.</strong> “Asymmetric Effects of the Business Cycle on Carbon Dioxide Emissions.” <em>Energy Economics,</em> 61: 289-297.
      </li>
-     
+
      <li>&nbsp;<strong>Sheldon, Tamara L</strong>. “Carbon Emissions and Economic Growth: A Replication and Extension.” <em>Energy Economics.</em></li>
-     
+
      <li><strong>Woodworth, Lindsey</strong>, Romano, Patrick S., and Holmes, James F. “Does Insurance Status Influence a Patient’s
         Hospital Charge?” <em>Applied Health Economics and Health Policy</em>, <em>15</em>(3), 353-362.
      </li>
-     
+
      <li>Knight, Thomas, Li, Fan, and<strong> Woodworth, Lindsey</strong>. “It’s My Party and I’ll Vote How I Want To: Experimental evidence of directional
         voting in two-candidate elections.” <em>Eastern Economic Journal</em>, <em>43</em>(4), 660-676.&nbsp;&nbsp;
      </li>
-     
+
   </ul>
-  
+
   <h3>2016 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John.</strong> "Collective Bargaining Systems and Macroeconomic and Microeconomic Flexibility:&nbsp;
         On the Design of Collective Bargaining Systems in Advanced Economies." <em>IZA Journal of Labor Policy,</em> 5: 19, 1-53.
      </li>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Evers, Katalin, and Teixeira, Paulino. "Is the Erosion Thesis Overblown?
         The Process of Alignment from Without in Germany." Industrial Relations, Vol. 55,
         No. 3, 415-443.
      </li>
-     
+
      <li><strong>Addison, John,</strong> Bellmann, Lutz, Evers, Katalin, and Teixeira, Paulino. "Is the Erosion Thesis Overblown?
         The Process of Alignment from Without in Germany." <em>Industrial Relations,</em> Vol. 55, No. 3, 415-443.
      </li>
-     
+
      <li><strong>Brookins, P.,</strong> Ryvkin, D. “Equilibrium existence in group contests.” <em>Economic Theory Bulletin,</em> 4(2): 265-276.
      </li>
-     
+
      <li>Cotti, Chad, <strong>Gordanier, John,</strong> and <strong>Ozturk, Orgul D.</strong> “Eat (and Drink) Better Tonight: Food Stamp Benefit Timing and Drunk Driving Fatalities.”
         <em>American Journal of Health Economics</em>, Fall 2016, Vol. 2, No. 4, 511-534.
      </li>
-     
+
      <li><strong>Jensen, Christian. </strong>“Price-Setting with Unobservable Elasticities of Demand: The Business-Cycle Effects
         of Heterogeneous Expectations,” <em>Macroeconomic Dynamics</em>, 20: 1101-1125.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> “On the Macroeconomic Effects of Heterogeneous Productivity Shocks,” <em>The B.E. Journal of Macroeconomics</em>, 16: 1-23.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> “Competition as an Engine of Economic Growth with Producer Heterogeneity,” <em>Macroeconomic Dynamics</em>, 20: 362-379.
      </li>
-     
+
      <li><strong>Matros, Alexander</strong> and Smirnov, Vladimir.&nbsp; “Duplicative search.” <em>Games and Economic Behavior</em>, 99: 1-22.
      </li>
-     
+
      <li><strong>Matros, Alexander</strong> and Possajennikov, Alex. “Tullock Contests May Be Revenue Superior to Auctions in
         a Symmetric Setting.” <em>Economics Letters</em>, 142: 74-77.
      </li>
-     
+
      <li><strong>Miao, Chun-Hui. </strong>“Licensing a technology standard”, <em>International Journal of Industrial Organization,</em> 47(2).
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> “Why Don't Prices Rise During Periods of Peak Demand? - Synchronize Demand to Relax
         Competition”, <em>The B.E. Journal of Economic Analysis &amp; Policy,</em> 16(3).
      </li>
-     
+
      <li>Blake, Christine, Frongillo, Edward, Jones, Sonya, <strong>McInnes, Melayne,</strong> and <strong>Ozturk, Orgul. D.</strong> “Development of a Structured Observational Method for the Systematic Assessment of
         School Food Choice Architecture.” <em>Ecology of Food and Nutrition</em>, Vol.55 No.2, 119-140.
      </li>
-     
+
      <li>Mann, Joshua, McDermott, Suzanne, <strong>McInnes, Melayne,</strong> and <strong>Ozturk, Orgul D.</strong> “Improved Targeting of Social Programs: An Application to a State Job Coaching Program
         for Adults with Intellectual Disabilities.” <em>Eastern Economic Journal</em>. Vol.42, 252-269.
      </li>
-     
+
      <li>Chai, Bo, Hardin, James, Mann, Joshua, McDermott, Suzanne, <strong>Ozturk, Orgul D.,</strong> Ouyang, Lijing, Royer, Julie, and Wang, Yinding. “Skin Ulcers and Mortality among
         Adolescents and Young Adults with Spina Bifida in South Carolina during 2000-2010.”
         <em>Journal of Child Neurology, </em>Vol 31, Issue 3, 370-7.
      </li>
-     
+
      <li><strong>Woodworth, Lindsey</strong>. “A Leak in the Lifeboat: The effect of Medicaid managed care on the vitality of
         safety-net hospitals.” <em>Journal of Regulatory Economics</em>,&nbsp;<em>50</em>(3), 251-270.
      </li>
-     
+
      <li><strong>Woodworth, Lindsey</strong>. “Smart as a Whip and Fit as a Fiddle: The effect of a diploma on health.” <em>American Journal of Health Economics</em>, <em>2</em>(3), 344-372.
      </li>
-     
+
      <li><strong>Zhan, Crystal.</strong> “Institutions, Social Norms, and Educational Attainment.” <em>Education Economics, </em>25(1): 22-44.
      </li>
-     
+
   </ul>
-  
+
   <h3>2014 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Breuer, Janice.</strong>&nbsp;“The Pattern of Convergence in the U.S. States.” (With William Hauk and John McDermott).
         <em>Applied Economics Letters</em>, 21:64-68.
      </li>
-     
+
      <li><strong>Breuer, Jan, McDermott, John, and Hauk, William.</strong> “The Return of Convergence in the U.S. States.”&nbsp; <em>Applied Economics Letters</em>, 21(1):64-68.
      </li>
-     
+
      <li>Hatfield, John and<strong>&nbsp;Hauk, William.</strong> "Electoral Regime and Trade Policy." <em>Journal of Comparative Economics</em>, 42(3):518-534.
      </li>
-     
+
      <li>Fortin, Nicole M.,<strong> Hill, Andrew</strong>, and Huang, Jeff<strong>.</strong> “Superstition in the Housing Market,” <em>Economic Inquiry</em>, 52(3): 974-993.&nbsp;
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong>&nbsp;"Discretionary Policy Exploiting Learning in a Sticky-Information Model of the Inflation-Output
         Trade-off: Bridging the Gap to Commitment."<em> Journal of Macroeconomics</em>, 40: 150-158.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "Replication and Returns to Scale in Production." <em>The B.E. Journal of Theoretical Economics</em>, 14: 1-22.&nbsp;
      </li>
-     
+
      <li><strong>Jones, Daniel B.</strong>, Linardi, Sera. “Wallflowers: Experimental Evidence of Reputation Avoidance” <em>Management Science</em>, 60(7):1757-1771.&nbsp;
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Bounded rationality and group size in Tullock contests: Experimental evidence."
         (With W. Lim and T. Turocy). <em>Journal of Economic Behavior &amp; Organization</em>, 99:155-167.&nbsp;
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "On the Use of Fines and Lottery Prizes to Increase Voter Turnout."&nbsp;(With J.&nbsp;Duffy).
         <em>Economics Bulletin</em> 34, 966-975.&nbsp;
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Determinants of Health Care Utilization by Race among Teenagers and Young Adults
         with Muscular Dystrophy.” (With Suzanne McDermott, Joshua Mann, Julie Royers, James
         Hardin and Lijing Quyang). <em>Medical Care</em>, 52 (1).&nbsp;
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Using State Administrative Data Sources to Study Adolescents and Young Adults with
         Rare Conditions.” (With Suzanne McDermott, Joshua Mann, Julie Royers, James Hardin,
         Lijing Ouyang, and Julie Bolen). J<em>ournal of General Internal Medicine</em>, 29(3): 732-738.
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “The Role of Gender and Sector in Promotion and Pay over a Career.” (With John T.
         Addison and Si Wang). <em>Journal of Human Capital,</em> 8(3).
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Welfare Reform and Children’s Short Run Attainments-A Structural Approach.” (With
         Hau Chyi and Weilong Zhang). <em>Contemporary Economic Policy</em>, 32(4).
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Job Promotion in Mid-Career: Gender, Recession and ‘Crowding.’” (With John Addison
         and Si Wang). <em>Monthly Labor Review</em>.&nbsp;
      </li>
-     
+
      <li><strong>Woodward, Douglas, Rolfe, R. </strong>and Ligthelm, A. “Micro-Enterprise, Multinational Business Support, and Poverty Alleviation
         in South Africa’s Informal Economy.” <em>Journal of African Business</em>, 15 (1):25-35.&nbsp;
      </li>
-     
+
      <li><strong>Woodward, Douglas</strong>, Figueiredo, O. and Guimarães, P. “Firm-Worker Matching in Industrial Clusters.”
         <em>Journal of Economic Geography</em>, 14:1-19.
      </li>
-     
+
   </ul>
-  
+
   <h3>2013 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “Ranking the Performance of Tennis Players:&nbsp; An Application to Women’s Professional
         Tennis.” <em>Journal of Quantitative Analysis in Sports</em>, 9: 367-378.&nbsp;
      </li>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “Minimum Wage Increases in a Recessionary Environment.” (With John Addison and Chad
         Cotti). <em>Labour Economics</em>, &nbsp;23: 30-39.&nbsp;
      </li>
-     
+
      <li><strong>Breuer, Janice.</strong> “Economic Depression in the World.” (With John McDermott). <em>Journal of Macroeconomics</em>, 38:227-242.&nbsp;
      </li>
-     
+
      <li><strong>Breuer, Janice.</strong> “Respect, Responsibility, and Development.” (With John McDermott).&nbsp; <em>Journal of Development Economics</em>, 105:36-47.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "The Gains from Short-Term Commitments," <em>Journal of Macroeconomics</em>, 35: 14-23.
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “The Effects of Single Mothers' Welfare Use and Employment Decisions on Children's
         Cognitive Development.” (With Hau Chyi). <em>Economic Inquiry</em>, 51(1): 675-706.&nbsp;
      </li>
-     
+
   </ul>
-  
+
   <h3>2012 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “The Effect of Minimum Wages on Labor Market Outcomes: County-Level Estimates from
         the Restaurant-and-Bar Sector.” <em>British Journal of Industrial Relations</em>, 50: 412-435.&nbsp;
      </li>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “Minimum Wages and Alcohol-Related Traffic Fatalities among Teens.” (With Scott Adams
         and Chad Cotti). <em>Review of Economics and Statistics</em>, 94: 828-840.&nbsp;
      </li>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “The Prevalence and Impact of Misstated Incomes on Mortgage Loan Applications.” (With
         Todd Vermilyea). <em>Journal of Housing Economics</em>, 21: 151-168.&nbsp;
      </li>
-     
+
      <li><strong>Breuer, Janice.</strong> “Culture, Caution, and Trust.” (With John McDermott). <em>Journal of Development Economics</em>, 97:15-23.&nbsp;
      </li>
-     
+
      <li><strong>Hauk, William.</strong> “Trade Restriction Indices and U.S. Trade Policy.”&nbsp;<em>Applied Economics Letters</em>, 19(8):795-799.&nbsp;
      </li>
-     
+
      <li><strong>Hauk, William.</strong> “U.S. Import and Export Elasticities:&nbsp; A Panel Data Approach.” <em>Empirical Economics</em>, 43(1):73-96.&nbsp;
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Sad-Loser Contests." <em>Journal of Mathematical Economics</em>, 48(3):155-162.&nbsp;
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Altruistic Versus Egoistic Behavior in a Public Good Game." <em>Journal of Economic Dynamics and Control</em>, 36(4): 642-656.
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Matching Auction with Winner's Curse and Imperfect Financial Markets." <em>Economics Letters</em>, 115(3):500-503.&nbsp;
      </li>
-     
+
      <li><strong>McDermott, John.</strong> “Culture, Caution, and Trust.” (With Janice Breuer). <em>Journal of Development Economics</em>, 97:15-23.&nbsp;
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Minimum Wages, Labor Market Institutions, and Female Employment and Unemployment:
         A Cross-Country Analysis.” (With John Addison). <em>Industrial and Labor Relations Review</em>, 65(4): 779-809.&nbsp;
      </li>
-     
+
      <li><strong>Woodward, Douglas.</strong> “Industry Location, Economic Development Incentives, and Clusters.” <em>Review of Regional Studies</em>, 42:5-23.
      </li>
-     
+
   </ul>
-  
+
   <h3>2011 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Hauk, William.</strong> "Protection with Many Sellers:&nbsp; An Application to Legislatures with Malapportionment."
         <em>Economics and Politics</em>, 23(3): 313-344.
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Competitive Behavior in Market Games: Evidence and Theory."&nbsp;(With J. Duffy and T.
         Temzelides). <em>Journal of Economic Theory</em>, 146(4): 1437-1463.&nbsp;
      </li>
-     
+
      <li><strong>Matros, Alexander.</strong> "Optimal Mechanisms for an Auction Mediator." (With A.&nbsp;Zapechelnyuk. <em>International Journal of Industrial Organization</em>, 29(4): 426-431.&nbsp;
      </li>
-     
+
      <li><strong>Miao, Chun-Hui and&nbsp;Gordanier, John.</strong> "On the Duration Technology Licensing." <em>International Journal of Industrial Organization</em>, 29(6).
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> "Planned Obsolescence and Monopoly Undersupply.”&nbsp;<em>Information Economics and Policy</em>, 23(1).&nbsp;
      </li>
-     
+
      <li><strong>Ozturk, Orgul.</strong> “Confessions of an Internet Monopolist: Demand Estimation for a Versioned Information
         Good.” (With Henry W. Chappell, Jr. and Paulo Guimarães). <em>Managerial and Decision Economics</em>, <a href="http://onlinelibrary.wiley.com/doi/10.1002/mde.v32.1/issuetoc">32(1): </a>1–15.&nbsp;
      </li>
-     
+
      <li><strong>Woodward, Douglas, </strong>Guimarães, P. and Figueiredo, O. “Accounting for Neighboring Effects in Measures of
         Spatial Concentration.” <em>Journal of Regional Science</em>, 51(4):678-693.&nbsp;
      </li>
-     
+
      <li><strong>Woodward, Douglas, Rolfe, R. </strong>and Guimarães, P. “The Viability of Informal Microenterprise in South Africa.” <em>Journal of Developmental Entrepreneurship</em>, 16(1):65-86.
      </li>
-     
+
   </ul>
-  
+
   <h3>2010 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “The Impact of Internal Migration on Married Couples’ Earnings in Britain.” <em>Economica</em>.&nbsp;
      </li>
-     
+
      <li><strong>Blackburn, McKinley.</strong> “Internal Migration and the Earnings of Married Couples in the U.S.”&nbsp; <em>Journal of Economic Geography</em>.&nbsp;
      </li>
-     
+
      <li><strong>Breuer, Janice B.</strong>, Ganguly, S. "Nominal Exchange Rate Volatility, Relative Price Volatility, and the
         Real Exchange Rate." <em>Journal of International Money and Finance</em>, 29:840-56.&nbsp;
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "Optimal Continuation versus the Timeless Perspective in Monetary Policy." (With
         Ben McCallum). <em>Journal of Money, Credit, and Banking</em>, 42: 1093-1107.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Mann, J., McDermott, S.&nbsp;and<strong>&nbsp;Ozturk, O.D.</strong> "Does Supported Employment Work?" <em>Journal of Policy Analysis and Management</em>, 29(3).
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>,&nbsp;Wood, S., Shinogle, J.A. "New Choices, New Information: Do Choice Abundance and
         Choice Complexity Hurt Aging Consumers' Medical Decision Making?" in Drolet, A., Schwarz,
         N., and Yoon, C. (eds.) <em>The Aging Consumer: Perspectives from Psychology and Economics</em>.
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> "Tying Compatibility and Planned Obsolescence."&nbsp;<em>Journal of Industrial Economics</em>, 58(3).
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> "Consumer Myopia, Standardization and Aftermarket Monopolization." <em>European Economic Review</em>, 54(7).&nbsp;
      </li>
-     
+
      <li>Guimarães, Paulo, Figueiredo, O. and<strong>&nbsp;Woodward, D.</strong> "Vertical&nbsp;Disintegration in Marshallian Industrial Districts."&nbsp;<em>Regional Science and Urban Economics</em>, 40(1):73-78.
      </li>
-     
+
   </ul>
-  
+
   <h3>2009 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T. </strong>and&nbsp;Surfield, C.J. "Atypical Work and Employment Continuity." <em>Industrial Relations</em>, Vol. 48, No. 4, October, pp. 655-683.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and&nbsp;Teixeira, P. "Are Good Industrial Relations Good for the Economy?" <em>German Economic Review</em>, Vol 10, No. 3, August, pp. 253-269.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Centeno, M. and Portugal, P.<strong>&nbsp;</strong>"Do Reservation Wages Really Decline:&nbsp;&nbsp; Some International Evidence on the Determinants
         of Reservation Wages." <em>Journal of Labor Research</em>, Vol. 40, No. 1, March, pp. 108.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Surfield, C.J. "Does Atypical Work Help the Jobless:&nbsp; Evidence from a CAEAS/CPS
         Cohort Analysis."&nbsp;<em>Applied Economics</em>, Vol. 41, No. 9, March, pp. 1077-1087.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L., Addison, J. </strong>and&nbsp;Cotti, C.&nbsp;"Do Minimum Wages Raise Employment?&nbsp; Evidence from the U.S. Retail-Trade
         Sector." <em>Labor Economics</em>, August 2009.
      </li>
-     
+
      <li>Guimarães, Paulo, Figueiredo, O. and<strong>&nbsp;Woodward, D.</strong> "Localization Economies and Establishment Size: Was Marshall Right After All?"<em> Journal of Economic Geography</em>, 9(6), 853-868.
      </li>
-     
+
      <li>Guimarães, Paulo, Figueiredo, O. and<strong>&nbsp;Woodward, D.</strong> "Dartboard Tests for the Location Quotient." R<em>egional Science and Urban Economics</em>, 39(3), 360-364.
      </li>
-     
+
      <li>Guimarães, Paulo and<strong> Woodward, D.</strong> "Porter's Cluster Strategy and Industrial Targeting in Targeting Regional Economic
         Development." Edited by Stephan J. Goetz, Steven Deller and Tom Harris.<em> Routledge Press</em>, pp. 68.83.
      </li>
-     
+
      <li><strong>Hauk, William</strong> and Wacziarg, R. "A Monte Carlo Study of Growth Regressions." <em>Journal of Economic Growth</em>, 14(2): 103-147.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Laury, S. and Swarthout, T. "Insurance Decisions for Low-Probability Losses." <em>Journal of Risk and Uncertainty</em>, 39(1).
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> "Limiting Compatibility in Two-Sided Markets." <em>Review of Network Economics</em>, 8(4), 346-364.
      </li>
-     
+
      <li><strong>Miao, Chun-Hui.</strong> "Competition in Quality Standards." <em>Journal of Industrial Economics</em>: Notes, 57(1), 2009
      </li>
-     
+
      <li><strong>Woodward, Douglas P.</strong> and Guimarães, P. "BMW in South Carolina: An Update," <em>Business and Economic Review</em>, Columbia, SC: University of South Carolina, 55 (2) January-March 2009: 13-21.
      </li>
-     
+
   </ul>
-  
+
   <h3>2008 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T.</strong>, Bellmann, L., Schank, T. and Teixeira, T. "The Demand for Labor: An Analysis Using
         Matched Employer-Employee Data from the German LIAB. Will the High Unskilled Worker
         Own-Wage Elasticity Please Stand Up?" <em>Journal of Labor Research</em>, Volume 29, Number 2, pp. 114-137, June 2008.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Belfield, Clive R. "Training, Unions, and Firm Performance," <em>Journal of Labor Market Research</em>/Zeitschrift für ArbeitsmarktForschung, Volume 40, Number 4, 2007, pp. 361-381, 2008.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Belfield, Clive R. "Performance Appraisal Systems: Do Brown and Heywood’s Results
         for Australia Hold Up for Britain?" <em>British Journal of Industrial Relations</em>, September 2008.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Portugal, P. "How do Different Entitlements to Unemployment Benefits Affect Transitions
         from Unemployment into Employment," <em>Economics Letters</em>, 101(3), 206-209.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Teixeira, P. "Works Councils and Employment Growth: A Rejoinder to Jirjahn," <em>Industrielle Beziehungen</em>, 15(4), 427-435.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> "Are Union Wage Differentials in the U.S. Falling?"<em> Industrial Relations,</em> July 2008.
      </li>
-     
+
      <li><strong>Woodward, Douglas P. </strong>and Guimarães, P. "Latino Immigration," <em>Business and Economic Review</em>, Columbia, SC: University of South Carolina, 54(3) April-June 2008: 3-9.
      </li>
-     
+
   </ul>
-  
+
   <h3>2007 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T.</strong> <em>Recent Developments in Labor Economics</em>, Cheltenham, England, and Northampton, MA: Edward Elgar, 2007.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Surfield, C. "Does Atypical Work Help the Jobless: Evidence from a CAEAS/CPS Cohort
         Analysis." <em>Applied Economics</em>, 2007.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Surfield, C. "Atypical Work and Pay," <em>Southern Economic Journal</em>, Vol. 73. No. 4, April 2007, pp. 1038-1065.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C., Schank, T. and Wagner, J. "Do Works Councils Inhibit Investment?"
         <em>Industrial and Labor Relations Review</em>, Vol. 60, No. 2, January 2007, pp. 187-203.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Bailey, R. and Siebert, W. "The Impact of De-unionization on Earnings Dispersion
         Revisited," <em>Research in Labor Economics</em>, Vol. 26, March 2007, pp. 337-363.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C. and Wagner, J. "The (Parlous) State of German Unions," <em>Journal of Labor Research</em>, Vol. 28, No. 1, Winter 2007, pp. 3-18.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> "Politico-Economic Causes of Labor Regulation in the United States: Rent Seeking,
         Alliances, Raising Rivals’ Costs (Even Lowering One’s Own?), and Interjurisdictional
         Competition," in Roland Vaubel and Peter Bernholz (eds.), Political Competition and
         Economic Regulation, London: <em>Routledge Press</em>, 2007, pp. 19-42.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Belfield, C. "Union Voice," in James T. Bennett and Bruce E. Kaufman (eds.), What
         Do Unions Do? A Twenty-Year Perspective. Piscataway, N.J.: <em>Transaction Publishers</em>, 2007, pp. 238-274.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> and Vermilyea, T. "The Role of Information Externalities and Scale Economies in Home
         Mortgage Lending Decisions." <em>Journal of Urban Economics</em>, January 2007.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> "Estimating Wage Differentials without Logarithms," Labour Economics, January 2007.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher and Shimpalee, P.</strong> "An Event Study of Institutions and Currency Crises." <em>Review of Financial Economics</em>, (16), pp. 274-90, 2007.
      </li>
-     
+
      <li>Guimarães P., Figueiredo O. and<strong> Woodward D.</strong> "Measuring the Localization of Economic Activity: A Parametric Approach," <em>Journal of Regional Science</em>, 47 (4), pp. 753-774, 2007.
      </li>
-     
+
      <li><strong>Hauk, William </strong>and Wacziarg, R. "Small States, Big Pork," Quarterly Journal of Political Science,
         Winter, 2, pp. 95-106, 2007 .
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "Optimal Implementation Delays: When Should Policies be Announced," <em>Scottish Journal of Political Economy</em>, 54, pp. 496-511, 2007.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong> "Controls for Risk Aversion in the Laboratory" (with Glenn W. Harrison, Eric Johnson,
         and E. Elisabet Rutsröm) in Measurement in Economics, A Handbook, Michael Boomans,
         ed., <em>Elsevier Press</em>, 2007.
      </li>
-     
+
   </ul>
-  
+
   <h3>2006 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T.</strong> "Editor’s Introduction," <em>Portuguese Economic Journal</em>, Vol. 5, No. 2, August 2006, pp. 67-68.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Barrett, C., Siebert, W.&nbsp;"Building Blocks in the Economics of Mandates," <em>Portuguese Economic Journal</em>, Vol. 5, No. 2, August 2006, pp. 69-87.
      </li>
-     
+
      <li><strong>Addison, John T.&nbsp;</strong>and Surfield, C. "The Use of Alternative Work Arrangements by the Jobless: Evidence
         from the CAEAS/CPS," <em>Journal of Labor Research</em>, Vol. 27, No. 2, Spring 2006, pp. 149- 162.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C., Schank, T. and Wagner, J. "Works Councils, Labor Productivity, and
         Plant Heterogeneity: First Evidence from Quantile Regressions" <em>Jahrbücher für Nationalökonomie und Statistik</em>, Vol. 226, No. 5, September 2006, pp. 505-518.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C., Schank, T. and Wagner, J. "Works Councils in the Production Process,"
         <em>Schmollers Jahrbuch</em>, Vol. 126, No. 2, 2006, pp. 251-283.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Teixeira, P. "The Effect of Works Councils on Employment Change," <em>Industrial Relations</em>, Vol. 45, No. 1, January 2006, pp. 1-25.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Bellmann, L., Schank, T. and Teixeira, P. "The Determinants of the Employment Structure:
         Wages, Trade, Technology, and Organizational Change," in Alex Bryson, John Forth,
         and Catherine Barber (eds.), <em>Making Linked Employer-Employee Data Relevant to Policy</em>, Department of Trade and Industry Occasional Paper No. 4, London, England: DTI, April
         2006, pp. 101-119.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L. </strong>and Vermilyea, T. "Racial Discrimination in Bank-Level and Market-Level Models of
         Mortgage Lending Decisions." <em>Journal of Financial Services Research</em>, April 2006.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher.</strong> "Problem Bank Loans, Conflicts of Interest, and Institutions." <em>Journal of Financial Stability</em>. October 2006. 2:266-85.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher, </strong>McNown, R. and Wallace, M. "Misleading Inferences in Panel Unit Root Tests: An Illustration
         from Purchasing Power Parity: A Reply." <em>Review of International Economics</em>. August 2006. 14:512-516.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher.</strong> "Currency Crises and Institutions." (with Pattama L. Shimpalee). <em>Journal of International Money and Finance</em>. February 2006. 25:125-45.
      </li>
-     
+
      <li><strong>Woodward, D., </strong>Figueiredo, O. and Guimarães, P. "Beyond the Silicon Valley: University R&amp;D and High
         Technology Location,"<em> Journal of Urban Economics</em>, 60(1), pp. 15-32, 2006.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "Expectations, Learning and Discretionary Policymaking," <em>International Journal of Central Banking</em>, 2, pp. 137-156, 2006.
      </li>
-     
+
      <li>Dias, J. and<strong> McDermott, John.</strong> "Institutions, Education, and Development: The Role of Entrepreneurs." <em>Journal of Development Economics</em> (2006).
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Johnson, E. and Shinogle, J. "What is the Economic Cost of Overweight Children?"
         <em>Eastern Economic Journal</em>, 32(1), Winter 2006, pp. 171-187.
      </li>
-     
+
   </ul>
-  
+
   <h3>2005 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T. </strong>and Teixeira, P. "Labor Adjustment in Two Countries with Bad Reputations: Analysis
         of Aggregate, Firm, and Flow Data for Portugal and Germany,"<em> International Economics and Economic Policy</em>, No. 4, February 2005, pp. 329-348.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> "The Status of the Collective Voice Model. Requiescat in Pace?" in Lutz Bellmann,
         Olaf Hübler, Wolfgang Meyer, and Gesine Stephan (eds.), <em>Instititutionen, Löhne und Beschäftigung</em>, Nürnberg: Institut für Arbeitsmarkt -und Berufsforschung der Bundesagentur für Arbeit,
         2005, pp. 11-29.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Teixeira, P. "What Have We Learned about the Employment Effects of Severance Pay?
         Further Iterations of Lazear et al.," <em>Empirica</em>, Vol. 32, No. 3-4, September 2005, pp. 345-368.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> "The Determinants of Firm Performance: Unions, Works Councils, and Employee Involvement/High
         Performance Work Practices," <em>Scottish Journal of Political Economy</em>, Vol. 52, No. 3, July 2005, pp. 406-450.
      </li>
-     
+
      <li><strong>Jensen, Christian.</strong> "Privacy Practices of Internet Users: Self-Reports versus Observed Behavior," with
         Carlos Jensen and Colin Potts,<em> International Journal of Human-Computer Studies</em>, 63, pp. 203-227, 2005.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Eckel, C., Ensminger, J., Fryer, R., Heiner, R., Samms, G., Sieberg, K., Solnick,
         S., Wilson, R. "Bobbing for Widgets: Compensating Wage Differentials," <em>Journal of Economic Education</em>, Vol. 36 (2), 2005.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Harrison, G., Johnson, E., Rutsröm, E. "Risk Aversion and Incentive Effects: Comment,"
         <em>American Economic Review</em>, 95 (3), June 2005, 897-901.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Harrison, G., Johnson, E., Rutsröm, E. "Temporal Stability of Estimates of Risk
         Aversion," <em>Applied Financial Economics Letters</em>, 1, 2005, 31-35.
      </li>
-     
+
      <li><strong>Woodward, Douglas P. and Rolfe, R.</strong> "African Apparel Exports, AGOA, and the Trade Preference Illusion," <em>Global Economy Journal</em>, Volume 5 (2005): Number 3, Article 6.
      </li>
-     
+
      <li><strong>Woodward, Douglas P. </strong>and Schunk, D. "Spending Stabilization Rules: A Solution to Recurring State Budget
         Crises?" <em>Public Budgeting and Finance</em>, Volume 25: Number 4 (Winter 2005): 105-124.
      </li>
-     
+
   </ul>
-  
+
   <h3>2004 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T. </strong>and Portugal, P. "Disincentive Effects of Unemployment Benefits on the Paths Out of
         Unemployment," <em>CESifo Forum</em>, Vol. 5, No. 1, Spring 2004, pp. 24-30.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Belfield, C. "Unions and Employment Growth: The One Constant?" <em>Industrial Relations</em>, Vol. 43, No. 2, April 2004, pp. 305-323.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Bellmann, L., Schnabel, C. and Wagner, J. "The Reform of the German Works Constitution
         Act: A Critical Appraisal," <em>Industrial Relations</em>, Vol. 43, No. 2, April 2004, pp. 392-420.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Bellmann, L. and Kölling, A. "Works Councils and Plant Closings in Germany," <em>British Journal of Industrial Relations</em>, Vol. 42, No. 1, March 2004, pp. 125-148.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Belfield, C. "Union Voice,"<em> Journal of Labor Research</em>, Vol. 25, No. 4, Fall 2004, pp. 563- 596.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and<strong>&nbsp;</strong>Portugal, P. "How Does the Unemployment Insurance System Shape the Time Profile of
         Jobless Duration?" <em>Economics Letters</em>, 2004, Vol. 85, No. 2, November, pp. 229-234.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C. and Wagner, J. "The Course of Research into the Economic Consequences
         of German Works Councils," <em>British Journal of Industrial Relations</em>, Vol. 42, No. 2, June 2004, pp. 255-281.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> "Unions and Establishment Performance: Evidence from the British Workplace Industrial/Employee
         Relations Surveys," in Phanindra V. Wunnava (ed.), <em>The Changing Role of Unions – New Forms of Representation</em>. Armonk, New York: M.E. Sharpe, 2004, pp. 281-319.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L. </strong>and Vermilyea, T. "Racial Disparities in Bank-Specific Mortgage Lending Models," <em>Economics Letters</em>, December 2004.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> "The Role of Test Scores in Explaining Race and Gender Differences in Wages," <em>Economics of Education Review</em>, December 2004.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher.</strong> "An Exegesis on Currency and Banking Crises."<em> Journal of Economic Surveys</em>. August 2004. 18:293-320.
      </li>
-     
+
      <li>Guimarães, P., Figueiredo, O. and<strong> Woodward, D.</strong> "Industrial Location Modeling: Extending the Random Utility Framework," <em>Journal of Regional Science</em>, 44(1), pp. 1-20, 2004.
      </li>
-     
+
      <li><strong>McInnes, Melayne M. </strong>and Grant, D. "The Influence of Malpractice Claims Experience on Rates of Cesarean
         Delivery: A Physician Level Analysis" <em>Inquiry</em>, Vol. 41, No. 2, pp. 170–188, 2004.
      </li>
-     
+
      <li><strong>Woodward, Douglas P., Rolfe, R. </strong>and&nbsp;Kagira, B. "Footloose and Tax Free: Incentive Preferences in Kenyan Export Processing
         Zones," <em>South African Journal of Economics</em>, Volume 72 (4), 2004: 784-807.
      </li>
-     
+
      <li><strong>Woodward, Douglas P., </strong>Barbosa, N. and Guimarães, P. "Foreign Firm Entry in an Open Economy: The Case of
         Portugal," <em>Applied Economics</em>. 36 (5): (2004) 465-72.
      </li>
-     
+
      <li><strong>Woodward, Douglas P. and Rolfe, R.</strong> "Attracting Foreign Investment Through Privatization: The Zambia Experience," <em>Journal of African Business</em>, 5 (1) Volume 5, Number 1,2004, 5-27.
      </li>
-     
+
   </ul>
-  
+
   <h3>2003 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T. </strong>and Schnabel, C. <em>International Handbook of Trade Unions</em>, Cheltenham, England, and Northampton, MA: Edward Elgar, 2003.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Welfens, Paul J.J. <em>Labor Markets and Social Security</em>, Berlin and New York: Springer Verlag, 2003 (2nd ed.).
      </li>
-     
+
      <li><strong>Addison, John T.&nbsp;</strong>and Portugal, P. "Unemployment Duration: A Competing Risks Model with Defective Risks,"
         <em>Journal of Human Resources</em>, Volume 38, No. 1, Winter 2003, pp. 156-191.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Bellmann, L., Schnabel, C.<strong>&nbsp;</strong>and Wagner, J. "German Works Councils Old and New: Incidence, Coverage, and Determinants,"
         <em>Schmollers Jahrbuch</em>, Volume 123, No. 3, 2003, pp. 339-358.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>, Heywood, J. and Wei, Xiangdong. "New Evidence on Unions and Plant Closings: Britain
         in the 1990s," <em>Southern Economic Journal</em>, Vol. 69, No. 4, April 2003, pp. 822-841.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Teixeira, P. "The Economics of Employment Protection," <em>Journal of Labor Research</em>, Vol. 24, No. 1, Winter 2003, pp. 85-129.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and Cohn, E. "The Economic Returns to Lifelong Learning in OECD Countries," in Clive
         R. Belfield and Henry M. Levin (eds.), <em>The Economics of Higher Education, The International Library of Critical Writings
            in Economics</em>, Series No. 165, Cheltenham, England, and Northampton, Mass.: Edward Elgar, 2003,
         pp. 3-57.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.&nbsp;</strong>and <strong>Vermilyea, T.</strong> "Racial Discrimination in Home Purchase Mortgage Lending Among Large National Banks."
         <em>Proceedings of the 2003 Joint Statistical Meetings</em>.
      </li>
-     
+
      <li><strong>Blackburn, McKinley L.</strong> "The Effects of the Welfare System on Marital Dissolution." <em>Journal of Population Economics</em>, August 2003.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher&nbsp;</strong>and Clements, L. "The Commodity Composition of US-Japanese Trade and the Yen/Dollar
         Real Exchange Rate." <em>Japan and the World Economy</em>. August 2003. 15:307-30.
      </li>
-     
+
      <li>Guimarães, P., Figueiredo, O. and<strong>&nbsp;Woodward, D.</strong>&nbsp;"A Tractable Approach to the Firm Location Decision Problem," <em>Review of Economics and Statistics</em>. 84(1), pp. 201-204, 2003.
      </li>
-     
+
      <li><strong>Jensen, Christian&nbsp;</strong>and McCallum, B. "The Non-Optimality of Proposed Monetary Policy Rules under Timeless-Perspective
         Commitment," <em>Economics Letters</em>, 77, pp. 163-168, 2003.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.&nbsp;</strong>and Laury, S. "Information and Insurance: An Experimental Investigation" <em>Journal of Risk and Insurance</em>, Vol. 70, No. 2, 2003.
      </li>
-     
+
      <li><strong>Woodward, Douglas P.&nbsp;</strong>and Schunk, D. "Incentives and Economic Development: The Case of BMW in South Carolina."&nbsp;<em>Financing Economic Development in the 21st Century</em>, Sammis B. White, Richard Bingham, and Edward W. Hill, eds. Armonk, New York: M.E.
         Sharpe, 2003, pp. 145-169.
      </li>
-     
+
      <li><strong>Woodward, Douglas P.</strong> "Adding a Stick to the Carrot: Economic Development Incentives with Clawbacks, Recisions,
         and Recalibrations." <em>Financing Economic Development in the 21st Century</em>, Sammis B. White, Richard Bingham, and Edward W. Hill, eds. Armonk, New York: M.E.
         Sharpe, 2003, pp. 70-91; reprinted from Economic Development Quarterly (with Larry
         Ledebur).
      </li>
-     
+
   </ul>
-  
+
   <h3>2002 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T.&nbsp;</strong>and Portugal, P. "Job Search Methods and Outcomes," <em>Oxford Economic Papers</em>, Vol. 54, No. 3, July 2002, pp. 505-533.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> and Belfield, C. "What Do We Know About the New European Works Councils? Some Preliminary
         Evidence from Britain," <em>Scottish Journal of Political Economy</em>, Vol. 49, No. 4, September 2002, pp. 418-444.
      </li>
-     
+
      <li><strong>Addison, John T.</strong> "Labor Policy in the EU: The New Emphasis on Education and Training under the Treaty
         of Amsterdam," <em>Journal of Labor Research</em>, Vol. 23, No. 2, Spring 2002, pp. 129-143.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher.</strong> "Series-specific Unit Root Tests with Panel Data." (with Robert McNown and Myles
         Wallace). <em>Oxford Bulletin of Economics and Statistics</em>. December 2002. 64:527-46.
      </li>
-     
+
      <li>Figueiredo, O., Guimarães, P. and <strong>Woodward, D.</strong> "Home-field Advantage: Location Decisions of Portuguese Entrepreneurs," <em>Journal of Urban Economics</em>. 52(2) pp. 341-361, 2002.
      </li>
-     
+
      <li><strong>McDermott, J.</strong> "Development Dynamics: Economic Integration and the Demographic Transition" <em>Journal of Economic Growth</em> (2002).
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Coller, M., Harrison, G. "Evaluating the Tobacco Settlement: Are the Damages Awards
         Too Much or Not Enough?"<em> American Journal of Public Health</em>, Vol. 92 (6), June 2002.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Fournier, G. "The Effects of Managed Care on Referrals and the Quality of Physicians:
         Theory and Evidence."<em> Journal of Industrial Economics</em>, Vol. L(4), December 2002.
      </li>
-     
+
      <li><strong>McInnes, Melayne M.</strong>, Coller, M., Harrison, G. "Cents on the Tobacco Dollar." <em>Business and Economic Review</em>, Vol. 48, No. 2, January, 2002.
      </li>
-     
+
      <li><strong>Woodward, Douglas P.</strong>, Teel, S., Robinson, R. "Coca- Cola as an Agent of Entrepreneurial Development in
         Emerging Economies," <em>International Journal of Entrepreneurship</em>, Volume 5 (2002) 1-18.
      </li>
-     
+
      <li>Woodward, Douglas P., Guimarães, P., Figueiredo, O. "Home-Field Advantage: Location
         Decisions of Portuguese Entrepreneurs,"<em> Journal of Urban Economics</em>, 52, (2002) 341-361.
      </li>
-     
+
   </ul>
-  
+
   <h3>2001 economics publications</h3>
-  
+
   <ul>
-     
+
      <li><strong>Addison, John T.</strong>, Schnabel, C. and Wagner, J. "Works Councils in Germany: Their Effects on Establishment
         Performance," <em>Oxford Economic Papers</em>, Vol. 53, No. 4, October 2001, pp. 659-694.
      </li>
-     
+
      <li><strong>Addison, John T. </strong>and&nbsp;Belfield, C. "Updating the Determinants of Firm Performance: Estimation Using
         the 1998 Workplace Employee Relations Survey," <em>British Journal of Industrial Relations</em>, Vol. 39, No. 3, September 2001, pp. 341-366.
      </li>
-     
+
      <li><strong>Addison, John T.&nbsp;</strong>and Siebert, W. "Union Security in Britain with an Addendum on New Labour's Reforms,"
         in Samuel Estreicher, Harry Katz, and Bruce Kaufman (eds.), <em>The Internal Governance and Organizational Effectiveness of Labor Unions: Essays in
            Honor of George Brooks</em>. New York: Kluwer Law International, 2001, pp. 249-278.
      </li>
-     
+
      <li><strong>Addison, John T.</strong>&nbsp;"European Union Labor Market Directives and Initiatives," in Samuel Estreicher (ed.),
         <em>Global Competition and the American Employment Landscape - As We Enter the 21st Century</em>. New York: Kluwer Law International, 2001, pp. 691-738.
      </li>
-     
+
      <li><strong>Breuer, Janice Boucher.</strong> "Misleading Inferences in Panel Unit Root Tests: An Illustration from Purchasing
         Power Parity" (with Robert McNown and Myles Wallace). <em>Review of International Economics</em>. August 2001. 9:482-93.
      </li>
@@ -1255,7 +1255,7 @@
                       <!-- END SYSTEM-REGION HOMEPAGE-BODY = HOMEPAGE-NEWS ++ HOMEPAGE-EVENTS ++ HOMEPAGE-MAIN-CONTENT -->
 
 
-                
+
                     <!-- END Main Body Content -->
 
 
@@ -1335,19 +1335,19 @@
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='faculty.html'>Faculty</a></li>
                     <li class=""><a class='level_2' href='research.html'>Research</a></li>
-                   </ul></li> 
+                   </ul></li>
                   <li class="closed"><a class='level_1' href='phd_students.html'>Ph.D. Program</a>
                     <ul class='no-bullet'>
                     <li class=""><a class='level_2' href='phd_students.html'>Ph.D. Directory</a></li>
-                    <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li>
+                    <!-- <li class=""><a class='level_2' href='job_market_candidates.html'>Job Market Candidates</a></li> -->
                     <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/phd_in_economics/'>Ph.D. Program</a></li>
-                    </ul></li> 
+                    </ul></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/master_of_arts_in_economics/'>Master’s Program</a></li>
                 <li class="closed"><a class='level_1' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>Undergraduate Program</a>
                   <ul class='no-bullet'>
                   <li class=""><a class='level_2' href='https://sc.edu/study/colleges_schools/moore/study/economics/degree_programs/bachelors/index.php'>BBA Economics</a></li>
                   <li class=""><a class='level_2' href='https://sc.edu/study/majors_and_degrees/economics.php'>BS and BA in Economics</a></li>
-                  </ul></li> 
+                  </ul></li>
                 <li class="closed"><a class='level_1' href='events.html'>Seminars &amp; Events</a></li>
                 </ul>
                 <!-- END SYSTEM-REGION NAV-MD-UP-UNIT -->


### PR DESCRIPTION
This PR updates the website by removing students who graduated in 2021 from the grad student directory and by hiding the job market candidates page.